### PR TITLE
Making logging within the node_helper backwards compatible

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -9,7 +9,7 @@ module.exports = NodeHelper.create({
      * @return void
      */
     start: function () {
-        Log.log("Starting node helper for: " + this.name);
+        this.debug("Starting node helper for: " + this.name);
 
         this.instances = [];
         this.clash_royale_api_url = "https://api.clashroyale.com/v1/";
@@ -59,7 +59,11 @@ module.exports = NodeHelper.create({
                 prefix = "[" + this.name + "] ";
             }
 
-            Log.log(prefix + string_to_log);
+            if (typeof Log !== "undefined" && typeof Log.log === "function") {
+				Log.log(prefix + string_to_log);
+			} else {
+				console.log(prefix + string_to_log);
+			}
         }
     },
     

--- a/node_helper.js
+++ b/node_helper.js
@@ -60,10 +60,10 @@ module.exports = NodeHelper.create({
             }
 
             if (typeof Log !== "undefined" && typeof Log.log === "function") {
-				Log.log(prefix + string_to_log);
-			} else {
-				console.log(prefix + string_to_log);
-			}
+                Log.log(prefix + string_to_log);
+            } else {
+                console.log(prefix + string_to_log);
+            }
         }
     },
     
@@ -116,8 +116,8 @@ module.exports = NodeHelper.create({
      * This will attempt to retrieve data from the Clash Royale API.
      * 
      * This function doesn't return anything, however, depending on the API
-	 * response it will send an appropriate socket notification to the front
-	 * end.
+     * response it will send an appropriate socket notification to the front
+     * end.
      * 
      * @param string instance_identifier 
      * 


### PR DESCRIPTION
I found that `Log.log` wouldn't work with MagicMirror versions prior to `v2.12.0`. I have tested this change with `v2.11.0`, `v2.12.0`, `v2.13.0`, and `v2.14.0`.